### PR TITLE
Switch MonixStreams to use Array[Byte]

### DIFF
--- a/monix/src/main/scala/sttp/capabilities/monix/MonixStreams.scala
+++ b/monix/src/main/scala/sttp/capabilities/monix/MonixStreams.scala
@@ -1,12 +1,10 @@
 package sttp.capabilities.monix
 
-import java.nio.ByteBuffer
-
 import monix.reactive.Observable
 import sttp.capabilities.Streams
 
 trait MonixStreams extends Streams[MonixStreams] {
-  override type BinaryStream = Observable[ByteBuffer]
+  override type BinaryStream = Observable[Array[Byte]]
   override type Pipe[A, B] = Observable[A] => Observable[B]
 }
 object MonixStreams extends MonixStreams


### PR DESCRIPTION
Justification:
- it seems that most of the monix related libraries works on `Array[Byte]` (e.g. monix-nio)
- because we keep that in `ByteBuffer` rather than arrays, we have to convert whenever we interact with some of monix built in stuff, this currently means 3 places (compression, reading response from file, writing response to file)
- by doing that we will decrease the number of places where we do conversion to one - we will convert as soon as we get `ByteBuffer` from `HttpClient`