### PR TITLE
Add `ArmeriaStreams`

### DIFF
--- a/armeria/src/main/scala/sttp/capabilities/armeria/ArmeriaStreams.scala
+++ b/armeria/src/main/scala/sttp/capabilities/armeria/ArmeriaStreams.scala
@@ -1,0 +1,12 @@
+package sttp.capabilities.armeria
+
+import com.linecorp.armeria.common.HttpData
+import org.reactivestreams.{Processor, Publisher}
+import sttp.capabilities.Streams
+
+trait ArmeriaStreams extends Streams[ArmeriaStreams] {
+  override type BinaryStream = Publisher[HttpData]
+  override type Pipe[A, B] = Processor[A, B]
+}
+
+object ArmeriaStreams extends ArmeriaStreams

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ val fs2_2_version: Option[(Long, Long)] => String = {
   case _             => "2.5.9"
 }
 val fs2_3_version = "3.2.4"
+val armeriaVersion = "1.14.0"
 
 excludeLintKeys in Global ++= Set(ideSkipProject)
 
@@ -140,6 +141,18 @@ lazy val akka = (projectMatrix in file("akka"))
     scalaVersions = List(scala2_12, scala2_13) ++ scala3,
     settings = commonJvmSettings ++ Seq(
       libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.6.18" % "provided"
+    )
+  )
+  .dependsOn(core)
+
+lazy val armeria = (projectMatrix in file("armeria"))
+  .settings(
+    name := "armeria"
+  )
+  .jvmPlatform(
+    scalaVersions = scala2 ++ scala3,
+    settings = commonJvmSettings ++ Seq(
+      libraryDependencies += "com.linecorp.armeria" % "armeria" % armeriaVersion
     )
   )
   .dependsOn(core)


### PR DESCRIPTION
I'm working on Armeria server and client interpreter for tapir.
I'd like to add `ArmeriaStreams` to share it between the server and client module.