### PR TITLE
Add `VertxStreams`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -244,3 +244,15 @@ lazy val zio = (projectMatrix in file("zio"))
     settings = commonNativeSettings
   )
   .dependsOn(core)
+
+lazy val vertx = (projectMatrix in file("vertx"))
+  .settings(
+    name := "vertx"
+  )
+  .jvmPlatform(
+    scalaVersions = List(scala2_12, scala2_13) ++ scala3,
+    settings = commonJvmSettings ++ Seq(
+      libraryDependencies += "io.vertx" % "vertx-core" % "4.4.0"
+    )
+  )
+  .dependsOn(core)

--- a/vertx/src/main/scala/sttp/capabilities/vertx/VertxStreams.scala
+++ b/vertx/src/main/scala/sttp/capabilities/vertx/VertxStreams.scala
@@ -1,0 +1,12 @@
+package sttp.capabilities.vertx
+
+import io.vertx.core.buffer.Buffer
+import io.vertx.core.streams.ReadStream
+import sttp.capabilities.Streams
+
+trait VertxStreams extends Streams[VertxStreams] {
+  override type BinaryStream = ReadStream[Buffer]
+  override type Pipe[A, B] = ReadStream[A] => ReadStream[B]
+}
+
+object VertxStreams extends VertxStreams


### PR DESCRIPTION
As defined in tapir [here](https://github.com/softwaremill/tapir/blob/c65d6bf1ead7fed363728d8c2d27645c6c0bda1f/server/vertx-server/src/main/scala/sttp/tapir/server/vertx/streams/ReadStreamCompatible.scala#L25-L30)