### PR TITLE
Add capability for Pekko Streams

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ val commonNativeSettings = commonSettings ++ Seq(
 )
 
 lazy val allProjectRefs =
-  core.projectRefs ++ ws.projectRefs ++ akka.projectRefs ++ armeria.projectRefs ++ fs2ce2.projectRefs ++ fs2.projectRefs ++ monix.projectRefs ++ zio1.projectRefs ++ zio.projectRefs ++ vertx.projectRefs
+  core.projectRefs ++ ws.projectRefs ++ akka.projectRefs ++ pekko.projectRefs ++ armeria.projectRefs ++ fs2ce2.projectRefs ++ fs2.projectRefs ++ monix.projectRefs ++ zio1.projectRefs ++ zio.projectRefs ++ vertx.projectRefs
 
 lazy val projectAggregates: Seq[ProjectReference] = if (sys.env.isDefinedAt("STTP_NATIVE")) {
   println("[info] STTP_NATIVE defined, including sttp-native in the aggregate projects")
@@ -142,6 +142,20 @@ lazy val akka = (projectMatrix in file("akka"))
     scalaVersions = scala2alive ++ scala3,
     settings = commonJvmSettings ++ Seq(
       libraryDependencies += "com.typesafe.akka" %% "akka-stream" % "2.6.20" % "provided"
+    )
+  )
+  .dependsOn(core)
+
+ThisBuild / resolvers += "Apache Snapshots".at("https://repository.apache.org/content/repositories/snapshots/") // Remove once Pekko makes a proper release
+
+lazy val pekko = (projectMatrix in file("pekko"))
+  .settings(
+    name := "pekko"
+  )
+  .jvmPlatform(
+    scalaVersions = scala2alive ++ scala3,
+    settings = commonJvmSettings ++ Seq(
+      libraryDependencies += "org.apache.pekko" %% "pekko-stream" % "0.0.0+26621-44d03df6-SNAPSHOT" % "provided"
     )
   )
   .dependsOn(core)

--- a/build.sbt
+++ b/build.sbt
@@ -146,8 +146,6 @@ lazy val akka = (projectMatrix in file("akka"))
   )
   .dependsOn(core)
 
-ThisBuild / resolvers += "Apache Snapshots".at("https://repository.apache.org/content/repositories/snapshots/") // Remove once Pekko makes a proper release
-
 lazy val pekko = (projectMatrix in file("pekko"))
   .settings(
     name := "pekko"
@@ -155,7 +153,7 @@ lazy val pekko = (projectMatrix in file("pekko"))
   .jvmPlatform(
     scalaVersions = scala2alive ++ scala3,
     settings = commonJvmSettings ++ Seq(
-      libraryDependencies += "org.apache.pekko" %% "pekko-stream" % "0.0.0+26621-44d03df6-SNAPSHOT" % "provided"
+      libraryDependencies += "org.apache.pekko" %% "pekko-stream" % "1.0.0" % "provided"
     )
   )
   .dependsOn(core)

--- a/pekko/src/main/scala/sttp/capabilities/pekko/PekkoStreams.scala
+++ b/pekko/src/main/scala/sttp/capabilities/pekko/PekkoStreams.scala
@@ -1,0 +1,12 @@
+package sttp.capabilities.pekko
+
+import org.apache.pekko
+import pekko.stream.scaladsl.{Flow, Source}
+import pekko.util.ByteString
+import sttp.capabilities.Streams
+
+trait PekkoStreams extends Streams[PekkoStreams] {
+  override type BinaryStream = Source[ByteString, Any]
+  override type Pipe[A, B] = Flow[A, B, Any]
+}
+object PekkoStreams extends PekkoStreams


### PR DESCRIPTION
The context of this change is to try and add pekko-http (open source akka fork) to sttp. Currently pekko (and pekko-http) only has snapshots released, the intention behind adding pekko-http to sttp at this stage is to identify if there are any problems before the initial full release.

Due to pekko still being a snapshot and sttp having multiple modules (with `sttp-shared` being a root module for sttp) I am not entirely sure whats the best way to handle this. You could just merge this PR into master and create a snapshot of `sttp-shared` but it can be said that this can "pollute" main with a module thats not ready yet. Other alternatives is to make a specific branch for `pekko` in this git repo which will eventually get merged into master once pekko is ready and you can make snapshot releases of sttp-shared from that `pekko` branch. Yet another option is to just make `sttp-shared` snapshots from this PR manually without merging it.