### PR TITLE
feat(zio): support Native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -232,12 +232,7 @@ lazy val zio1 = (projectMatrix in file("zio1"))
 lazy val zio = (projectMatrix in file("zio"))
   .settings(
     name := "zio",
-    libraryDependencies ++= Seq("dev.zio" %%% "zio-streams" % zio2Version, "dev.zio" %%% "zio" % zio2Version) ++
-      Seq(
-        "dev.zio" %%% "zio-test" % zio2Version % Test,
-        "dev.zio" %%% "zio-test-sbt" % zio2Version % Test
-      ),
-    testFrameworks += TestFrameworks.ZIOTest
+    libraryDependencies ++= Seq("dev.zio" %%% "zio-streams" % zio2Version, "dev.zio" %%% "zio" % zio2Version)
   )
   .jvmPlatform(
     scalaVersions = scala2 ++ scala3,

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ def dependenciesFor(version: String)(deps: (Option[(Long, Long)] => ModuleID)*):
 val commonSettings = commonSmlBuildSettings ++ ossPublishSettings ++ Seq(
   organization := "com.softwaremill.sttp.shared",
   libraryDependencies ++= Seq(
-    "org.scalatest" %% "scalatest" % scalaTestVersion % Test
+    "org.scalatest" %%% "scalatest" % scalaTestVersion % Test
   ),
   mimaPreviousArtifacts := Set.empty,
   versionScheme := Some("semver-spec")
@@ -59,14 +59,15 @@ val commonJsSettings = commonSettings ++ Seq(
     }
   },
   libraryDependencies ++= Seq(
-    "org.scala-js" %%% "scalajs-dom" % "2.8.0"
+    "org.scala-js" %%% "scalajs-dom" % "2.8.0",
+    "io.github.cquiroz" %%% "scala-java-time" % "2.6.0" % Test
   )
 )
 
 val commonNativeSettings = commonSettings ++ Seq(
   ideSkipProject := true,
   libraryDependencies ++= Seq(
-    "org.scala-native" %%% "test-interface" % nativeVersion
+    "io.github.cquiroz" %%% "scala-java-time" % "2.6.0" % Test
   )
 )
 
@@ -231,7 +232,12 @@ lazy val zio1 = (projectMatrix in file("zio1"))
 lazy val zio = (projectMatrix in file("zio"))
   .settings(
     name := "zio",
-    libraryDependencies ++= Seq("dev.zio" %%% "zio-streams" % zio2Version, "dev.zio" %%% "zio" % zio2Version)
+    libraryDependencies ++= Seq("dev.zio" %%% "zio-streams" % zio2Version, "dev.zio" %%% "zio" % zio2Version) ++
+      Seq(
+        "dev.zio" %%% "zio-test" % zio2Version % Test,
+        "dev.zio" %%% "zio-test-sbt" % zio2Version % Test
+      ),
+    testFrameworks += TestFrameworks.ZIOTest
   )
   .jvmPlatform(
     scalaVersions = scala2 ++ scala3,
@@ -240,6 +246,10 @@ lazy val zio = (projectMatrix in file("zio"))
   .jsPlatform(
     scalaVersions = scala2alive ++ scala3,
     settings = commonJsSettings ++ browserChromeTestSettings
+  )
+  .nativePlatform(
+    scalaVersions = scala3,
+    settings = commonNativeSettings
   )
   .dependsOn(core)
 

--- a/fs2/src/test/scala/sttp/capabilities/fs2/Fs2StreamsTest.scala
+++ b/fs2/src/test/scala/sttp/capabilities/fs2/Fs2StreamsTest.scala
@@ -1,13 +1,22 @@
 package sttp.capabilities.fs2
 
 import cats.effect.IO
-import cats.effect.unsafe.implicits.global
+import cats.effect.unsafe
 import fs2._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.capabilities.StreamMaxLengthExceededException
 
 class Fs2StreamsTest extends AsyncFlatSpec with Matchers {
+
+  implicit val runtime: unsafe.IORuntime = unsafe.IORuntime(
+    executionContext,
+    executionContext,
+    unsafe.IORuntime.global.scheduler,
+    unsafe.IORuntime.global.shutdown,
+    unsafe.IORuntime.global.config
+  )
+
   behavior of "Fs2Streams"
 
   it should "Pass all bytes if limit is not exceeded" in {

--- a/fs2/src/test/scala/sttp/capabilities/fs2/Fs2StreamsTest.scala
+++ b/fs2/src/test/scala/sttp/capabilities/fs2/Fs2StreamsTest.scala
@@ -2,20 +2,16 @@ package sttp.capabilities.fs2
 
 import cats.effect.IO
 import cats.effect.unsafe
+import cats.effect.unsafe.implicits.global
 import fs2._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import sttp.capabilities.StreamMaxLengthExceededException
+import scala.concurrent.ExecutionContext
 
 class Fs2StreamsTest extends AsyncFlatSpec with Matchers {
 
-  implicit val runtime: unsafe.IORuntime = unsafe.IORuntime(
-    executionContext,
-    executionContext,
-    unsafe.IORuntime.global.scheduler,
-    unsafe.IORuntime.global.shutdown,
-    unsafe.IORuntime.global.config
-  )
+  override implicit val executionContext: ExecutionContext = unsafe.IORuntime.global.compute
 
   behavior of "Fs2Streams"
 

--- a/zio/src/test/scala/sttp/capabilities/zio/ZioStreamsTest.scala
+++ b/zio/src/test/scala/sttp/capabilities/zio/ZioStreamsTest.scala
@@ -1,54 +1,44 @@
 package sttp.capabilities.zio
 
-import org.scalatest.flatspec.AsyncFlatSpec
-import org.scalatest.matchers.should.Matchers
 import sttp.capabilities.StreamMaxLengthExceededException
 import zio._
 import zio.stream.ZStream
+import zio.test._
 
-class ZioStreamsTest extends AsyncFlatSpec with Matchers {
-  behavior of "ZioStreams"
+object ZioStreamsTest extends ZIOSpecDefault {
+  def spec: Spec[TestEnvironment, Any] = suite("ZioStreams")(
+    test("should Pass all bytes if limit is not exceeded") {
+      // given
+      val inputByteCount = 8192
+      val maxBytes = 8192L
+      val inputStream = ZStream.fromIterator(Iterator.fill[Byte](inputByteCount)('5'.toByte))
 
-  implicit val r: Runtime[Any] = Runtime.default
+      // when
+      val stream = ZioStreams.limitBytes(inputStream, maxBytes)
 
-  it should "Pass all bytes if limit is not exceeded" in {
-    // given
-    val inputByteCount = 8192
-    val maxBytes = 8192L
-    val inputStream = ZStream.fromIterator(Iterator.fill[Byte](inputByteCount)('5'.toByte))
+      // then
+      for {
+        count <- stream.runFold(0L)((acc, _) => acc + 1)
+      } yield assertTrue(count == inputByteCount)
+    },
+    test("should Fail stream if limit is exceeded") {
+      val inputByteCount = 8192
+      val maxBytes = 8191L
+      val inputStream = ZStream.fromIterator(Iterator.fill[Byte](inputByteCount)('5'.toByte))
 
-    // when
-    val stream = ZioStreams.limitBytes(inputStream, maxBytes)
+      // when
+      val stream = ZioStreams.limitBytes(inputStream, maxBytes)
 
-    // then
-    Unsafe.unsafe(implicit u =>
-      r.unsafe.runToFuture(stream.runFold(0L)((acc, _) => acc + 1).map { count =>
-        count shouldBe inputByteCount
-      })
-    )
-  }
-
-  it should "Fail stream if limit is exceeded" in {
-    // given
-    val inputByteCount = 8192
-    val maxBytes = 8191L
-    val inputStream = ZStream.fromIterator(Iterator.fill[Byte](inputByteCount)('5'.toByte))
-
-    // when
-    val stream = ZioStreams.limitBytes(inputStream, maxBytes)
-
-    // then
-    Unsafe.unsafe(implicit u =>
-      r.unsafe.runToFuture(
-        stream.runLast
-          .flatMap(_ => ZIO.succeed(fail("Unexpected end of stream")))
-          .catchSome {
+      // then
+      for {
+        limit <- stream.runLast.flip
+          .flatMap {
             case StreamMaxLengthExceededException(limit) =>
-              ZIO.succeed(limit shouldBe maxBytes)
+              ZIO.succeed(limit)
             case other =>
-              ZIO.succeed(fail(s"Unexpected failure cause: $other"))
+              ZIO.fail(s"Unexpected failure cause: $other")
           }
-      )
-    )
-  }
+      } yield assertTrue(limit == maxBytes)
+    }
+  )
 }


### PR DESCRIPTION
This PR should implement support for Scala Native for the zio module. The zio tests are refactored to zio-tests because running zio's to futures for Scalatest has issues (tests finishing because tests run on different execution context than the zio's). Pure zio-tests work way smoother. 

It also fixes test setups for JS, seemed like JS suits were ignored. 

closes #431 