### PR TITLE
feat(zio): support Native for Scala 2.12 and 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -243,7 +243,7 @@ lazy val zio = (projectMatrix in file("zio"))
     settings = commonJsSettings ++ browserChromeTestSettings
   )
   .nativePlatform(
-    scalaVersions = scala3,
+    scalaVersions = scala2alive ++ scala3,
     settings = commonNativeSettings
   )
   .dependsOn(core)


### PR DESCRIPTION
In my previous PR I missed 2.12 and 2.13. They should work without any code changes.