### PR TITLE
Also catch fatal exceptions (e.g. InterruptedException) in MonadError.handleError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ project/plugins/project/
 .worksheet
 
 .idea*
+.vscode
 
 .keys*
 
@@ -28,6 +29,6 @@ lowered.hnir
 # Bloop / Metals
 .bloop/
 .metals/
-project/metals.sbt
+metals.sbt
 
 .bsp

--- a/core/src/main/scala/sttp/monad/MonadError.scala
+++ b/core/src/main/scala/sttp/monad/MonadError.scala
@@ -23,10 +23,10 @@ trait MonadError[F[_]] {
   def error[T](t: Throwable): F[T]
   protected def handleWrappedError[T](rt: F[T])(h: PartialFunction[Throwable, F[T]]): F[T]
   def handleError[T](rt: => F[T])(h: PartialFunction[Throwable, F[T]]): F[T] = {
-    Try(rt) match {
-      case Success(v)                     => handleWrappedError(v)(h)
-      case Failure(e) if h.isDefinedAt(e) => h(e)
-      case Failure(e)                     => error(e)
+    try handleWrappedError(rt)(h)
+    catch {
+      case e: Throwable if h.isDefinedAt(e) => h(e)
+      case e: Throwable                     => error(e)
     }
   }
 


### PR DESCRIPTION
This is needed in Tapir, to properly catch when a server logic is interrupted, and react properly to update the metrics (and perform other cleanup)