### PR TITLE
Fix FutureMonadTest flakiness on Scala 2.12 under CI load

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ sttp is a family of Scala HTTP-related projects, and currently includes:
 Add the following dependency:
 
 ```scala
-"com.softwaremill.sttp.shared" %% "core" % "1.5.1"
+"com.softwaremill.sttp.shared" %% "core" % "1.5.2"
 ```
 
 sttp-shared is available for Scala 2.12, 2.13, 3.3, Scala.JS and Scala Native.

--- a/core/src/test/scalajvm/sttp/monad/FutureMonadTest.scala
+++ b/core/src/test/scalajvm/sttp/monad/FutureMonadTest.scala
@@ -1,23 +1,23 @@
 package sttp.monad
 
-import org.scalatest.concurrent.ScalaFutures.convertScalaFuture
+import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Seconds, Span}
 
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class FutureMonadTest extends AnyFlatSpec with Matchers {
+class FutureMonadTest extends AnyFlatSpec with Matchers with ScalaFutures {
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = Span(10, Seconds))
   implicit val m: MonadError[Future] = new FutureMonad()
 
   it should "ensure" in {
     val ran = new AtomicBoolean(false)
 
-    intercept[RuntimeException] {
-      m.ensure2((throw new RuntimeException("boom!")): Future[Int], Future(ran.set(true))).futureValue
-    }
-
+    val result = m.ensure2((throw new RuntimeException("boom!")): Future[Int], Future(ran.set(true)))
+    result.failed.futureValue shouldBe a[RuntimeException]
     ran.get shouldBe true
   }
 }


### PR DESCRIPTION
The test used `intercept[RuntimeException]` around `.futureValue`, but `TestFailedException` (thrown on timeout) is a `RuntimeException` subclass. On a loaded CI machine, the 150ms default patience expired before the finalizer future completed, causing the intercept to silently catch the timeout instead of the expected "boom!" exception. Result: `ran.get` was `false` even though `intercept` appeared to succeed.

Fix: mix in `ScalaFutures` to allow a 10s patience override, and use `.failed.futureValue` so a timeout throws `TestFailedException` uncaught rather than being mistaken for the expected exception.